### PR TITLE
Revamp menu item card layout

### DIFF
--- a/src/components/menu/ItemCard.jsx
+++ b/src/components/menu/ItemCard.jsx
@@ -16,49 +16,58 @@ const ItemCard = ({ item, onEdit, onDelete }) => {
   const imageSrc = item.image || item.imageUrl || null;
 
   return (
-    <Card className="overflow-hidden">
-      <CardHeader className="p-3 pb-0 space-y-1">
-        {/* Image or Placeholder */}
-        <div className="mb-2">
+    <Card className="group relative h-full overflow-hidden border border-border/50 bg-gradient-to-br from-background via-background to-muted/30 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl">
+      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary/60 via-primary to-primary/60" />
+      <CardHeader className="p-4 pb-0 space-y-3">
+        <div className="relative rounded-lg border border-border/40 bg-gradient-to-br from-muted/40 via-muted/20 to-background shadow-inner">
           {imageSrc ? (
             <img
               src={imageSrc}
               alt={item.name}
-              className="w-full h-24 sm:h-28 md:h-32 lg:h-36 object-cover rounded-sm border"
+              className="h-28 w-full rounded-lg object-cover transition-transform duration-500 group-hover:scale-[1.02]"
             />
           ) : (
-            <div className="w-full h-24 sm:h-28 md:h-32 lg:h-36 flex items-center justify-center rounded-sm border bg-muted text-muted-foreground">
-              <ImageIcon className="w-6 h-6" />
-              <span className="ml-2 text-xs">No Image</span>
+            <div className="flex h-28 w-full flex-col items-center justify-center gap-1 rounded-lg bg-muted/50 text-muted-foreground">
+              <ImageIcon className="h-7 w-7" />
+              <span className="text-xs font-medium">No Image Available</span>
             </div>
           )}
+          <div className="pointer-events-none absolute bottom-2 left-2">
+            <Badge
+              variant={item.available ? 'outline' : 'destructive'}
+              className="backdrop-blur-sm bg-background/80 text-[10px] font-semibold uppercase tracking-wide"
+            >
+              {item.available ? 'Available' : 'Unavailable'}
+            </Badge>
+          </div>
         </div>
-        <CardTitle className="text-sm font-semibold leading-tight truncate">
-          {item.name}
-        </CardTitle>
-        <CardDescription className="text-xs line-clamp-2">
-          {item.description}
-        </CardDescription>
+        <div className="space-y-1">
+          <CardTitle className="text-base font-semibold leading-tight text-foreground line-clamp-2">
+            {item.name}
+          </CardTitle>
+          <CardDescription className="text-sm text-muted-foreground line-clamp-3">
+            {item.description}
+          </CardDescription>
+        </div>
       </CardHeader>
 
-      <CardContent className="p-3 pt-2">
-        <div className="flex items-center justify-between mb-2">
-          <span className="font-semibold text-base">
-            ₱{Number(item.price).toFixed(2)}
-          </span>
-          <Badge
-            variant={item.available ? 'outline' : 'destructive'}
-            className="text-[10px] px-1.5 py-0.5"
-          >
-            {item.available ? 'Available' : 'Unavailable'}
-          </Badge>
+      <CardContent className="p-4 pt-3 space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Starting at</p>
+            <p className="text-lg font-semibold text-primary">
+              ₱{Number(item.price).toFixed(2)}
+            </p>
+          </div>
+          {item.category && (
+            <Badge variant="secondary" className="rounded-full px-3 py-1 text-[10px] font-medium">
+              {item.category}
+            </Badge>
+          )}
         </div>
-        <p className="text-xs text-muted-foreground">
-          Category: {item.category}
-        </p>
       </CardContent>
 
-      <CardFooter className="p-3 pt-0 flex justify-end gap-2">
+      <CardFooter className="p-4 pt-0 flex items-center justify-end gap-2 border-t border-border/40 bg-background/60 backdrop-blur-sm">
         <Button
           variant="outline"
           size="sm"


### PR DESCRIPTION
## Summary
- refresh the menu item card with a more polished layout, gradient accents, and hover polish
- highlight availability, pricing, and category details with improved badges and typography

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b6c36a4483248e6c5803b803ca2f